### PR TITLE
Delete common/src/main/resources/assets/minecraft/texts directory

### DIFF
--- a/common/src/main/resources/assets/minecraft/texts/splashes.txt
+++ b/common/src/main/resources/assets/minecraft/texts/splashes.txt
@@ -1,1 +1,0 @@
-Enchanting Overhauled!


### PR DESCRIPTION
fixes the vanilla splash text being overridden by getting rid of /texts/splashes.txt